### PR TITLE
[OSDEV-2867] Add CloudWatch alarm for RDS DatabaseConnections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
   `alarm_database_connections_threshold` (default `90`, ~80% of
   `db.t3.micro` default `max_connections`). Override per instance class.
 
+## 3.2.0
+
+- Upgrade default PostgreSQL engine version from 13 to 16.
+- Update default parameter group from `default.postgres13` to
+  `default.postgres16`.
+
+## 3.1.0
+
+- Add `allow_major_version_upgrade` and `apply_immediately` variables
+  (both default `false`).
+- Upgrade default PostgreSQL engine version from 11.5 to 13 and default
+  parameter group from `default.postgres11` to `default.postgres13`.
+- Rename deprecated `name` argument to `db_name` on `aws_db_instance`.
+- Use `aws_db_instance.postgresql.identifier` for CloudWatch alarm
+  dimensions instead of `id`.
+- Raise the AWS provider requirement from `>= 2.33.0` to `>= 3.0.0`.
+
 ## 3.0.0
 
 - Add support for Terraform 0.12; 0.12 is now the minimum supported version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,6 @@
   (both default `false`).
 - Upgrade default PostgreSQL engine version from 11.5 to 13 and default
   parameter group from `default.postgres11` to `default.postgres13`.
-- Rename deprecated `name` argument to `db_name` on `aws_db_instance`.
-- Use `aws_db_instance.postgresql.identifier` for CloudWatch alarm
-  dimensions instead of `id`.
-- Raise the AWS provider requirement from `>= 2.33.0` to `>= 3.0.0`.
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.3.0
+
+- Add a CloudWatch alarm for RDS `DatabaseConnections`, configurable via
+  `alarm_database_connections_threshold` (default `90`, ~80% of
+  `db.t3.micro` default `max_connections`). Override per instance class.
+
 ## 3.0.0
 
 - Add support for Terraform 0.12; 0.12 is now the minimum supported version.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ module "postgresql_rds" {
   alarm_disk_queue_threshold = "10"
   alarm_free_disk_threshold = "5000000000"
   alarm_free_memory_threshold = "128000000"
+  alarm_database_connections_threshold = "90"
   alarm_actions = ["arn:aws:sns..."]
   ok_actions = ["arn:aws:sns..."]
   insufficient_data_actions = ["arn:aws:sns..."]
@@ -101,6 +102,7 @@ If you're curious to know more, see the discussion within https://github.com/ter
 - `alarm_free_disk_threshold` - Free disk alarm threshold in bytes (default: `5000000000`)
 - `alarm_free_memory_threshold` - Free memory alarm threshold in bytes (default: `128000000`)
 - `alarm_cpu_credit_balance_threshold` - CPU credit balance threshold (default: `30`). Only used for `db.t*` instance types
+- `alarm_database_connections_threshold` - DatabaseConnections alarm threshold (default: `90`). Tune to ~80% of instance `max_connections` (`LEAST(DBInstanceClassMemory/9531392, 5000)`)
 - `alarm_actions` - List of ARNs to be notified via CloudWatch when alarm enters ALARM state
 - `ok_actions` - List of ARNs to be notified via CloudWatch when alarm enters OK state
 - `insufficient_data_actions` - List of ARNs to be notified via CloudWatch when alarm enters INSUFFICIENT_DATA state

--- a/main.tf
+++ b/main.tf
@@ -190,3 +190,23 @@ resource "aws_cloudwatch_metric_alarm" "database_cpu_credits" {
   ok_actions                = var.ok_actions
   insufficient_data_actions = var.insufficient_data_actions
 }
+
+resource "aws_cloudwatch_metric_alarm" "database_connections" {
+  alarm_name          = "alarm${var.environment}DatabaseServerDatabaseConnections-${var.database_identifier}"
+  alarm_description   = "Database server connection count"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseConnections"
+  namespace           = "AWS/RDS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = var.alarm_database_connections_threshold
+
+  dimensions = {
+    DBInstanceIdentifier = aws_db_instance.postgresql.identifier
+  }
+
+  alarm_actions             = var.alarm_actions
+  ok_actions                = var.ok_actions
+  insufficient_data_actions = var.insufficient_data_actions
+}

--- a/variables.tf
+++ b/variables.tf
@@ -206,6 +206,12 @@ variable "alarm_cpu_credit_balance_threshold" {
   description = "CPU credit balance threshold (only for db.t* instance types)"
 }
 
+variable "alarm_database_connections_threshold" {
+  default     = 90
+  type        = number
+  description = "DatabaseConnections alarm threshold. Tune per instance class (~80% of max_connections from LEAST(DBInstanceClassMemory/9531392, 5000))"
+}
+
 variable "alarm_actions" {
   type        = list
   description = "List of ARNs to be notified via CloudWatch when alarm enters ALARM state"


### PR DESCRIPTION
## Summary
[OSDEV-2867](https://opensupplyhub.atlassian.net/browse/OSDEV-2867)

Add a CloudWatch metric alarm for RDS `DatabaseConnections`, alongside the existing CPU/disk/memory/credit alarms.

- New variable: `alarm_database_connections_threshold` (default `90`, ~80% of `db.t3.micro` default `max_connections`)
- Consumers with larger instance classes should override (e.g. ~80% of `LEAST(DBInstanceClassMemory/9531392, 5000)`)
- Version bump documented as **3.3.0** in CHANGELOG — please tag `3.3.0` on merge

Follow-up for Open Supply Hub: wire the threshold per environment and bump the module ref in [open-supply-hub#1155](https://github.com/opensupplyhub/open-supply-hub/pull/1155).

## Test plan

- [x] Review alarm resource matches existing alarm naming/SNS action patterns
- [ ] After merge, tag `3.3.0`
- [x] Confirm a consumer can pass `alarm_database_connections_threshold` and create the alarm